### PR TITLE
Updating common Jenkins pipeline steps to override 'latest' in docker build with branch name and ID

### DIFF
--- a/vars/javaIntegrationPipeline.groovy
+++ b/vars/javaIntegrationPipeline.groovy
@@ -36,7 +36,7 @@ def call(body) {
                     unstash 'workspace'
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
-                            def customImage = docker.build(pipelineParams.dockerRepository)
+                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${env.BUILD_ID}")
                             customImage.push("${env.BRANCH_NAME}-${env.BUILD_ID}")
                         }
                     }

--- a/vars/nodeIntegrationPipeline.groovy
+++ b/vars/nodeIntegrationPipeline.groovy
@@ -46,7 +46,7 @@ def call(body) {
                     unstash 'workspace'
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
-                            def customImage = docker.build(pipelineParams.dockerRepository)
+                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${env.BUILD_ID}")
                             customImage.push("${env.BRANCH_NAME}-${env.BUILD_ID}")
                         }
                     }


### PR DESCRIPTION
Supplying explicit version tag to docker build command prevents a collision on 'latest' when two or more builds running on the same host are running concurrently with a race condition on build and push tag.

Shared repository change version of https://github.com/Civil-Service-Human-Resources/identity-management/pull/18