### PR TITLE
Change Build ID to include timestamp for uniqueness

### DIFF
--- a/vars/javaIntegrationPipeline.groovy
+++ b/vars/javaIntegrationPipeline.groovy
@@ -41,8 +41,10 @@ def call(body) {
                     unstash 'workspace'
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
-                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${env.BUILD_ID}")
-                            customImage.push("${env.BRANCH_NAME}-${env.BUILD_ID}")
+                            def now = new Date()
+                            now.format("ddMMyy-HHmmss")
+                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${now}")
+                            customImage.push("${env.BRANCH_NAME}-${now}")
                         }
                     }
                     stash 'workspace'

--- a/vars/javaIntegrationPipeline.groovy
+++ b/vars/javaIntegrationPipeline.groovy
@@ -42,8 +42,8 @@ def call(body) {
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
                             def now = new Date()
-                            now.format("ddMMyy-HHmmss")
-                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${now}")
+                            def formatted = now.format("ddMMyy-HHmmss")
+                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${formatted}")
                             customImage.push("${env.BRANCH_NAME}-${now}")
                         }
                     }

--- a/vars/javaIntegrationPipeline.groovy
+++ b/vars/javaIntegrationPipeline.groovy
@@ -42,8 +42,8 @@ def call(body) {
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
                             def now = new Date()
-                            def formatted = now.format("yyyyMMdd-HHmmss")
-                            def buildId = "${env.BRANCH_NAME}-${env.BUILD_ID}-${formatted}"
+                            def formattedCurrentDateTime = now.format("yyyyMMdd-HHmmss")
+                            def buildId = "${env.BRANCH_NAME}-${env.BUILD_ID}-${formattedCurrentDateTime}"
                             def customImage = docker.build(pipelineParams.dockerRepository+":${buildId}")
                             customImage.push("${buildId}")
                         }

--- a/vars/javaIntegrationPipeline.groovy
+++ b/vars/javaIntegrationPipeline.groovy
@@ -42,9 +42,10 @@ def call(body) {
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
                             def now = new Date()
-                            def formatted = now.format("ddMMyy-HHmmss")
-                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${formatted}")
-                            customImage.push("${env.BRANCH_NAME}-${now}")
+                            def formatted = now.format("yyyyMMdd-HHmmss")
+                            def buildId = "${env.BRANCH_NAME}-${env.BUILD_ID}-${formatted}"
+                            def customImage = docker.build(pipelineParams.dockerRepository+":${buildId}")
+                            customImage.push("${buildId}")
                         }
                     }
                     stash 'workspace'

--- a/vars/nodeIntegrationPipeline.groovy
+++ b/vars/nodeIntegrationPipeline.groovy
@@ -47,9 +47,10 @@ def call(body) {
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
                             def now = new Date()
-                            def formatted = now.format("ddMMyy-HHmmss")
-                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${formatted}")
-                            customImage.push("${env.BRANCH_NAME}-${now}")
+                            def formatted = now.format("yyyyMMdd-HHmmss")
+                            def buildId = "${env.BRANCH_NAME}-${env.BUILD_ID}-${formatted}"
+                            def customImage = docker.build(pipelineParams.dockerRepository+":${buildId}")
+                            customImage.push("${buildId}")
                         }
                     }
                 }

--- a/vars/nodeIntegrationPipeline.groovy
+++ b/vars/nodeIntegrationPipeline.groovy
@@ -47,8 +47,8 @@ def call(body) {
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
                             def now = new Date()
-                            now.format("ddMMyy-HHmmss")
-                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${now}")
+                            def formatted = now.format("ddMMyy-HHmmss")
+                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${formatted}")
                             customImage.push("${env.BRANCH_NAME}-${now}")
                         }
                     }

--- a/vars/nodeIntegrationPipeline.groovy
+++ b/vars/nodeIntegrationPipeline.groovy
@@ -46,8 +46,10 @@ def call(body) {
                     unstash 'workspace'
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
-                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${env.BUILD_ID}")
-                            customImage.push("${env.BRANCH_NAME}-${env.BUILD_ID}")
+                            def now = new Date()
+                            now.format("ddMMyy-HHmmss")
+                            def customImage = docker.build(pipelineParams.dockerRepository+":${env.BRANCH_NAME}-${now}")
+                            customImage.push("${env.BRANCH_NAME}-${now}")
                         }
                     }
                 }

--- a/vars/nodeIntegrationPipeline.groovy
+++ b/vars/nodeIntegrationPipeline.groovy
@@ -47,8 +47,8 @@ def call(body) {
                     script {
                         docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
                             def now = new Date()
-                            def formatted = now.format("yyyyMMdd-HHmmss")
-                            def buildId = "${env.BRANCH_NAME}-${env.BUILD_ID}-${formatted}"
+                            def formattedCurrentDateTime = now.format("yyyyMMdd-HHmmss")
+                            def buildId = "${env.BRANCH_NAME}-${env.BUILD_ID}-${formattedCurrentDateTime}"
                             def customImage = docker.build(pipelineParams.dockerRepository+":${buildId}")
                             customImage.push("${buildId}")
                         }


### PR DESCRIPTION
Build ID can be reset to 1 in Jenkins, which can lead to conflicts/overwrites of containers in ACR. This change will add the current timestamp to the build ID to generate a new unique ID, circumventing the issue of the Build ID being reset.